### PR TITLE
Migrate Compose libraries to Compose BoM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,7 @@ android {
 dependencies {
     arrayOf(
         project(":shimmer"),
+        platform(Lib.Compose.composeBom),
         Lib.Compose.material,
         Lib.Compose.icons,
         Lib.Compose.navigation,

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -9,18 +9,20 @@ object Lib {
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21"
 
     object Compose {
+        private const val composeBomVersion = "2023.05.01"
+        const val composeBom = "androidx.compose:compose-bom:$composeBomVersion"
+
         const val compiler = "1.4.7"
-        const val runtime = "androidx.compose.runtime:runtime:1.4.3"
 
-        const val composeUi = "1.4.3"
-        const val ui = "androidx.compose.ui:ui:$composeUi"
-        const val tooling = "androidx.compose.ui:ui-tooling:$composeUi"
+        const val runtime = "androidx.compose.runtime:runtime"
 
-        const val foundation = "androidx.compose.foundation:foundation:1.4.3"
+        const val ui = "androidx.compose.ui:ui"
+        const val tooling = "androidx.compose.ui:ui-tooling"
 
-        const val composeMaterial = "1.4.3"
-        const val material = "androidx.compose.material:material:$composeMaterial"
-        const val icons = "androidx.compose.material:material-icons-extended:$composeMaterial"
+        const val foundation = "androidx.compose.foundation:foundation"
+
+        const val material = "androidx.compose.material:material"
+        const val icons = "androidx.compose.material:material-icons-extended"
 
         const val navigation = "androidx.navigation:navigation-compose:2.5.3"
     }

--- a/shimmer/build.gradle.kts
+++ b/shimmer/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 
 dependencies {
     arrayOf(
+        platform(Lib.Compose.composeBom),
         Lib.Compose.runtime,
         Lib.Compose.foundation,
         Lib.Compose.ui,


### PR DESCRIPTION
Migrate individual versioning for Compose libraries to [Bill of Materials](https://developer.android.com/jetpack/compose/bom).

It is easier to maintain and ensures the compatibility between the libraries

